### PR TITLE
fix: use another url to fetch bills which always gives the full list

### DIFF
--- a/src/urlService.js
+++ b/src/urlService.js
@@ -30,10 +30,9 @@ class UrlService {
    * @param endDate: a moment date
    */
   getBillUrl (endDate, monthsBack) {
+    const formatedEndDate = endDate.format('DD/MM/YYYY')
     const startDate = endDate.subtract(monthsBack, 'months').format('DD/MM/YYYY')
-    return `${this.getBaseUrl()}afficherPaiementsComplementaires&DateDebut=${startDate}&DateFin=${endDate}\
-&Beneficiaire=tout_selectionner&afficherReleves=false&afficherIJ=false&afficherInva=false&afficherRentes=false\
-&afficherRS=false&indexPaiement=&idNotif=`
+    return `${this.getBaseUrl()}Rechercher&DateDebut=${startDate}&DateFin=${formatedEndDate}&Beneficiaire=tout_selectionner&afficherReleves=false&afficherIJ=false&afficherPT=false&afficherInva=false&afficherRentes=false&afficherRS=false&indexPaiement=&idNotif=`
   }
 
   getDetailsUrl (idPaiement, naturePaiement, indexGroupe, indexPaiement) {


### PR DESCRIPTION
With the previous url, the connector could only fetch one bill from time to time.